### PR TITLE
Add domain handler + tests – ordering: get all restaurants #23 

### DIFF
--- a/packages/sdk/api.spec.json
+++ b/packages/sdk/api.spec.json
@@ -866,23 +866,23 @@
         "properties": {
           "id": { "type": "string", "pattern": "^[0-9a-fA-F]{24}$", "example": "6200218668fc82e7bdf15088" },
           "name": { "type": "string", "example": "Resto bar" },
-          "type": { "type": "string", "example": "włoskie" },
-          "tags": { "example": ["tradycyjna", "oryginalne składniki"], "type": "array", "items": { "type": "string" } },
-          "photo": { "type": "string" },
+          "description": { "type": "string" },
+          "cuisineType": { "example": ["włoska"], "type": "array", "items": { "type": "string" } },
+          "tags": { "example": ["pizza", "zdrowa"], "type": "array", "items": { "type": "string" } },
           "dishes": { "type": "array", "items": { "$ref": "#/components/schemas/ShortenedDishDto" } }
         },
-        "required": ["id", "name", "type", "tags", "photo", "dishes"]
+        "required": ["id", "name", "description", "cuisineType", "tags", "dishes"]
       },
       "RestaurantWithoutDishesDto": {
         "type": "object",
         "properties": {
           "id": { "type": "string", "pattern": "^[0-9a-fA-F]{24}$", "example": "6200218668fc82e7bdf15088" },
           "name": { "type": "string", "example": "Resto bar" },
-          "type": { "type": "string", "example": "włoskie" },
-          "tags": { "example": ["tradycyjna", "oryginalne składniki"], "type": "array", "items": { "type": "string" } },
-          "photo": { "type": "string" }
+          "description": { "type": "string" },
+          "cuisineType": { "example": ["włoska"], "type": "array", "items": { "type": "string" } },
+          "tags": { "example": ["pizza", "zdrowa"], "type": "array", "items": { "type": "string" } }
         },
-        "required": ["id", "name", "type", "tags", "photo"]
+        "required": ["id", "name", "description", "cuisineType", "tags"]
       },
       "RestaurantListDto": {
         "type": "object",

--- a/packages/server/src/restaurants/RestaurantsModule.ts
+++ b/packages/server/src/restaurants/RestaurantsModule.ts
@@ -5,12 +5,13 @@ import { RestaurantController } from './api/RestaurantController';
 import { Restaurant, RestaurantSchema } from './database';
 import { PartnerDishController } from './dishes/api/PartnerDishController';
 import { RestaurantDishController } from './dishes/api/RestaurantDishController';
+import { ListRestaurantsHandler } from './domain/ListRestaurantsHandler';
 import { RestaurantsFacade } from './infra';
 
 @Module({
   imports: [MongooseModule.forFeature([{ name: Restaurant.name, schema: RestaurantSchema }])],
   controllers: [RestaurantController, RestaurantDishController, PartnerDishController],
-  providers: [RestaurantsFacade],
+  providers: [RestaurantsFacade, ListRestaurantsHandler],
   exports: [RestaurantsFacade],
 })
 class RestaurantsModule {}

--- a/packages/server/src/restaurants/api/RestaurantController.ts
+++ b/packages/server/src/restaurants/api/RestaurantController.ts
@@ -12,11 +12,14 @@ import {
   PaginationQuery,
   Url,
 } from '../../shared';
+import { ListRestaurantsHandler } from '../domain/ListRestaurantsHandler';
 import { RestaurantDto } from './RestaurantDto';
 import { RestaurantListDto } from './RestaurantListDto';
 
 @ApiController({ path: 'restaurants', name: 'Restaurants', description: 'Operations on restaurants' })
 class RestaurantController {
+  constructor(private readonly listRestaurantsHandler: ListRestaurantsHandler) {}
+
   @ApiObjectIdParam()
   @ApiGet({ name: 'restaurant', response: RestaurantDto })
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -28,7 +31,7 @@ class RestaurantController {
 
   @ApiList({ name: 'restaurants', response: RestaurantListDto, link: true })
   async list(@Pagination() pagination: PaginationQuery, @Res({ passthrough: true }) res: Response, @Url() url: URL) {
-    const paginatedRestaurants = { data: [], pages: 1 }; // TODO: Hook up ListRestaurantsHandler
+    const paginatedRestaurants = await this.listRestaurantsHandler.exec(pagination);
     res.setHeader('Link', createPaginationLink(url, paginatedRestaurants.pages));
     return plainToInstance(RestaurantListDto, paginatedRestaurants);
   }

--- a/packages/server/src/restaurants/api/RestaurantDto.ts
+++ b/packages/server/src/restaurants/api/RestaurantDto.ts
@@ -2,24 +2,31 @@ import { ApiProperty, OmitType, PickType } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 
 import { ApiObjectIdProperty } from '../../shared';
+import { CuisineTypes, RESTAURANT_CONSTANTS, RestaurantTags } from '../database';
 import { ShortenedDishDto } from '../dishes/api/DishDto';
 
-// TODO: add min and max length restrictions once work on RestaurantSchema gets finished, possibly move examples to consts
 class RestaurantDto {
   @ApiObjectIdProperty()
   readonly id: string;
 
-  @ApiProperty({ example: 'Resto bar' })
+  @ApiProperty({
+    minLength: RESTAURANT_CONSTANTS.NAME.MIN_LENGTH,
+    maxLength: RESTAURANT_CONSTANTS.NAME.MAX_LENGTH,
+    example: 'Resto bar',
+  })
   readonly name: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    maxLength: RESTAURANT_CONSTANTS.DESCRIPTION.MAX_LENGTH,
+    example: 'Opis restauracji.',
+  })
   readonly description: string;
 
-  @ApiProperty({ example: ['włoska'] })
-  readonly cuisineType: string[];
+  @ApiProperty({ enum: CuisineTypes, enumName: 'CuisineTypeEnum', isArray: true, example: ['włoska'] })
+  readonly cuisineType: CuisineTypes[];
 
-  @ApiProperty({ example: ['pizza', 'zdrowa'] })
-  readonly tags: string[];
+  @ApiProperty({ enum: RestaurantTags, enumName: 'RestaurantTagEnum', isArray: true, example: ['pizza', 'zdrowa'] })
+  readonly tags: RestaurantTags[];
 
   @Type(() => ShortenedDishDto)
   @ApiProperty({ type: [ShortenedDishDto] })

--- a/packages/server/src/restaurants/api/RestaurantDto.ts
+++ b/packages/server/src/restaurants/api/RestaurantDto.ts
@@ -12,14 +12,14 @@ class RestaurantDto {
   @ApiProperty({ example: 'Resto bar' })
   readonly name: string;
 
-  @ApiProperty({ example: 'włoskie' })
-  readonly type: string;
-
-  @ApiProperty({ example: ['tradycyjna', 'oryginalne składniki'] })
-  readonly tags: string[];
-
   @ApiProperty()
-  readonly photo: string;
+  readonly description: string;
+
+  @ApiProperty({ example: ['włoska'] })
+  readonly cuisineType: string[];
+
+  @ApiProperty({ example: ['pizza', 'zdrowa'] })
+  readonly tags: string[];
 
   @Type(() => ShortenedDishDto)
   @ApiProperty({ type: [ShortenedDishDto] })

--- a/packages/server/src/restaurants/database/RestaurantSchema.ts
+++ b/packages/server/src/restaurants/database/RestaurantSchema.ts
@@ -1,4 +1,4 @@
-import { Schema, SchemaFactory } from '@nestjs/mongoose';
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Exclude, Expose } from 'class-transformer';
 import { ObjectId } from 'mongodb';
 import { Document } from 'mongoose';
@@ -10,6 +10,10 @@ type RestaurantDocument = Restaurant & Document<ObjectId>;
   collection: 'restaurants',
 })
 class Restaurant {
+  @Expose()
+  @Prop({ default: false })
+  profileCompleted: boolean;
+
   @Expose()
   readonly id: string;
 }

--- a/packages/server/src/restaurants/database/RestaurantSchema.ts
+++ b/packages/server/src/restaurants/database/RestaurantSchema.ts
@@ -114,5 +114,5 @@ class Restaurant {
 
 const RestaurantSchema = SchemaFactory.createForClass(Restaurant);
 
-export { Restaurant, RestaurantSchema };
+export { CuisineTypes, Restaurant, RESTAURANT_CONSTANTS, RestaurantSchema, RestaurantTags };
 export type { RestaurantDocument };

--- a/packages/server/src/restaurants/database/RestaurantSchema.ts
+++ b/packages/server/src/restaurants/database/RestaurantSchema.ts
@@ -64,6 +64,7 @@ const RESTAURANT_CONSTANTS = Object.freeze({
   collection: 'restaurants',
 })
 class Restaurant {
+  @Expose()
   @Prop({
     minlength: RESTAURANT_CONSTANTS.NAME.MIN_LENGTH,
     maxlength: RESTAURANT_CONSTANTS.NAME.MAX_LENGTH,
@@ -102,10 +103,6 @@ class Restaurant {
   @Expose()
   @Prop()
   tags: RestaurantTags[];
-
-  @Expose()
-  @Prop({ default: false })
-  profileCompleted: boolean;
 
   @Expose()
   @Prop({ default: false })

--- a/packages/server/src/restaurants/domain/ListRestaurantsHandler.ts
+++ b/packages/server/src/restaurants/domain/ListRestaurantsHandler.ts
@@ -10,8 +10,9 @@ class ListRestaurantsHandler implements Handler<PaginationQuery, Paginated<Resta
 
   async exec(req: PaginationQuery): Promise<Paginated<Restaurant>> {
     const offset = (req.page - 1) * req.limit;
-    const restaurantDocsQuery = this.restaurantModel.find({ profileCompleted: true }).skip(offset).limit(req.limit);
-    const countQuery = this.restaurantModel.countDocuments();
+    const queryFilter = { profileCompleted: true };
+    const restaurantDocsQuery = this.restaurantModel.find(queryFilter).skip(offset).limit(req.limit);
+    const countQuery = this.restaurantModel.countDocuments(queryFilter);
     const [restaurantDocs, count] = await Promise.all([restaurantDocsQuery.exec(), countQuery.exec()]);
     return { data: plainToInstance(Restaurant, restaurantDocs), pages: Math.ceil(count / req.limit) };
   }

--- a/packages/server/src/restaurants/domain/ListRestaurantsHandler.ts
+++ b/packages/server/src/restaurants/domain/ListRestaurantsHandler.ts
@@ -1,0 +1,20 @@
+import { InjectModel } from '@nestjs/mongoose';
+import { plainToInstance } from 'class-transformer';
+import { Model } from 'mongoose';
+
+import { Handler, Paginated, PaginationQuery } from '../../shared';
+import { Restaurant, RestaurantDocument } from '../database';
+
+class ListRestaurantsHandler implements Handler<PaginationQuery, Paginated<Restaurant>> {
+  constructor(@InjectModel(Restaurant.name) private restaurantModel: Model<RestaurantDocument>) {}
+
+  async exec(req: PaginationQuery): Promise<Paginated<Restaurant>> {
+    const offset = (req.page - 1) * req.limit;
+    const restaurantDocsQuery = this.restaurantModel.find({ profileCompleted: true }).skip(offset).limit(req.limit);
+    const countQuery = this.restaurantModel.countDocuments();
+    const [restaurantDocs, count] = await Promise.all([restaurantDocsQuery.exec(), countQuery.exec()]);
+    return { data: plainToInstance(Restaurant, restaurantDocs), pages: Math.ceil(count / req.limit) };
+  }
+}
+
+export { ListRestaurantsHandler };

--- a/packages/server/test/Restaurants.test.ts
+++ b/packages/server/test/Restaurants.test.ts
@@ -14,8 +14,19 @@ describe(`${PATH}`, () => {
   it('GET /', async () => {
     // Given
     const restaurants = [
-      { name: 'Restaurant 1', type: 'Italian', tags: [], photo: '', profileCompleted: true },
+      {
+        name: 'Restaurant 1',
+        description: 'Test!',
+        cuisineType: ['italian'],
+        tags: ['pizza'],
+        profileCompleted: true,
+      },
       { name: 'Restaurant 2', profileCompleted: false },
+      {
+        name: 'Restaurant 3',
+        description: 'Test!',
+        profileCompleted: true,
+      },
     ];
     await fixture.db.restaurantModel.create(restaurants);
 
@@ -23,8 +34,7 @@ describe(`${PATH}`, () => {
     const resp = await fixture.req.get(PATH);
 
     // Then
-    console.log(resp.body);
     expect(resp.status).toBe(HttpStatus.OK);
-    expect(resp.body.data).toHaveLength(restaurants.filter((rest) => rest.profileCompleted).length);
+    expect(resp.body.data).toHaveLength(restaurants.filter((rest) => rest?.profileCompleted).length);
   });
 });

--- a/packages/server/test/Restaurants.test.ts
+++ b/packages/server/test/Restaurants.test.ts
@@ -17,7 +17,7 @@ describe(`${PATH}`, () => {
       {
         name: 'Restaurant 1',
         description: 'Test!',
-        cuisineType: ['italian'],
+        cuisineType: ['włoska'],
         tags: ['pizza'],
         profileCompleted: true,
       },

--- a/packages/server/test/Restaurants.test.ts
+++ b/packages/server/test/Restaurants.test.ts
@@ -1,0 +1,30 @@
+import { HttpStatus } from '@nestjs/common';
+
+import { initE2eFixture } from './E2eFixture';
+
+const PATH = '/api/restaurants';
+
+describe(`${PATH}`, () => {
+  const fixture = initE2eFixture();
+
+  afterEach(async () => {
+    await fixture.db.restaurantModel.deleteMany();
+  });
+
+  it('GET /', async () => {
+    // Given
+    const restaurants = [
+      { name: 'Restaurant 1', type: 'Italian', tags: [], photo: '', profileCompleted: true },
+      { name: 'Restaurant 2', profileCompleted: false },
+    ];
+    await fixture.db.restaurantModel.create(restaurants);
+
+    // When
+    const resp = await fixture.req.get(PATH);
+
+    // Then
+    console.log(resp.body);
+    expect(resp.status).toBe(HttpStatus.OK);
+    expect(resp.body.data).toHaveLength(restaurants.filter((rest) => rest.profileCompleted).length);
+  });
+});


### PR DESCRIPTION
Handler + teścik gotowe. Założyłem, że użytkownik widzi tylko restauracje z uzupełnionym profilem, bo to nieźle całość upraszcza, a chyba jest poprawne (co da userowi przeglądanie restauracji która nie podała nawet nazwy).

---

Jako że i tak musiałem dotknąć DTO, zrobiłem przy okazji TODO które było tam przypięte, bo #34  jest już na mainie, także:
- Dodane `description`.
- Na `name` i `description` są ograniczenia na długość ze schemy.
- `type` -> `cuisineType` zgodnie z bazą danych.
- `tags` i `cuisineType` są ograniczone do wartości enuma.
- Tymczasowo usunięte `photo`, póki nie mamy na niego gotowej logiki (blokowałoby test).