### PR TITLE
Add handler + test - ordering: get restaurant #46

### DIFF
--- a/packages/sdk/api.spec.json
+++ b/packages/sdk/api.spec.json
@@ -878,47 +878,71 @@
         },
         "required": ["email", "role", "password", "rememberMe"]
       },
-      "ShortenedDishDto": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "string", "pattern": "^[0-9a-fA-F]{24}$", "example": "6200218668fc82e7bdf15088" },
-          "name": { "type": "string", "example": "Chilli con carne" },
-          "photo": { "type": "string" },
-          "description": {
-            "type": "string",
-            "example": "Składa się z soczewicy, świeżych pomidorów  i bazylii oraz kuminu"
-          },
-          "callories": { "type": "number" }
-        },
-        "required": ["id", "name", "photo", "description", "callories"]
+      "CuisineTypeEnum": {
+        "type": "string",
+        "enum": [
+          "amerykańska",
+          "azjatycka",
+          "europejska",
+          "arabska",
+          "chińska",
+          "francuska",
+          "gruzińska",
+          "grecka",
+          "indyjska",
+          "włoska",
+          "japońska",
+          "żydowska",
+          "koreańska",
+          "libańska",
+          "śródziemnomorska",
+          "meksykanśka",
+          "polska",
+          "tajska",
+          "turecka",
+          "wietnamska"
+        ]
+      },
+      "RestaurantTagEnum": {
+        "type": "string",
+        "enum": [
+          "fast food",
+          "wegańska",
+          "wegetariańska",
+          "kawiarnia",
+          "zdrowa",
+          "street food",
+          "desery",
+          "pizza",
+          "burgery",
+          "sushi",
+          "kebab",
+          "gluten free"
+        ]
       },
       "RestaurantDto": {
         "type": "object",
         "properties": {
           "id": { "type": "string", "pattern": "^[0-9a-fA-F]{24}$", "example": "6200218668fc82e7bdf15088" },
-          "name": { "type": "string", "example": "Resto bar" },
-          "description": { "type": "string" },
-          "cuisineType": { "example": ["włoska"], "type": "array", "items": { "type": "string" } },
-          "tags": { "example": ["pizza", "zdrowa"], "type": "array", "items": { "type": "string" } },
-          "dishes": { "type": "array", "items": { "$ref": "#/components/schemas/ShortenedDishDto" } }
-        },
-        "required": ["id", "name", "description", "cuisineType", "tags", "dishes"]
-      },
-      "RestaurantWithoutDishesDto": {
-        "type": "object",
-        "properties": {
-          "id": { "type": "string", "pattern": "^[0-9a-fA-F]{24}$", "example": "6200218668fc82e7bdf15088" },
-          "name": { "type": "string", "example": "Resto bar" },
-          "description": { "type": "string" },
-          "cuisineType": { "example": ["włoska"], "type": "array", "items": { "type": "string" } },
-          "tags": { "example": ["pizza", "zdrowa"], "type": "array", "items": { "type": "string" } }
+          "name": { "type": "string", "minLength": 1, "maxLength": 50, "example": "Resto bar" },
+          "description": { "type": "string", "maxLength": 500, "example": "Opis restauracji." },
+          "cuisineType": {
+            "type": "array",
+            "example": ["włoska"],
+            "items": { "$ref": "#/components/schemas/CuisineTypeEnum" }
+          },
+          "tags": {
+            "type": "array",
+            "example": ["pizza", "zdrowa"],
+            "items": { "$ref": "#/components/schemas/RestaurantTagEnum" }
+          }
         },
         "required": ["id", "name", "description", "cuisineType", "tags"]
       },
       "RestaurantListDto": {
         "type": "object",
         "properties": {
-          "data": { "type": "array", "items": { "$ref": "#/components/schemas/RestaurantWithoutDishesDto" } },
+          "data": { "type": "array", "items": { "$ref": "#/components/schemas/RestaurantDto" } },
           "pages": { "type": "number" }
         },
         "required": ["data", "pages"]
@@ -989,7 +1013,7 @@
         "type": "object",
         "properties": {
           "id": { "type": "string", "pattern": "^[0-9a-fA-F]{24}$", "example": "6200218668fc82e7bdf15088" },
-          "name": { "type": "string", "example": "Resto bar" }
+          "name": { "type": "string", "minLength": 1, "maxLength": 50, "example": "Resto bar" }
         },
         "required": ["id", "name"]
       },

--- a/packages/server/src/restaurants/RestaurantsModule.ts
+++ b/packages/server/src/restaurants/RestaurantsModule.ts
@@ -5,13 +5,14 @@ import { RestaurantController } from './api/RestaurantController';
 import { Restaurant, RestaurantSchema } from './database';
 import { PartnerDishController } from './dishes/api/PartnerDishController';
 import { RestaurantDishController } from './dishes/api/RestaurantDishController';
+import { GetRestaurantHandler } from './domain/GetRestaurantHandler';
 import { ListRestaurantsHandler } from './domain/ListRestaurantsHandler';
 import { RestaurantsFacade } from './infra';
 
 @Module({
   imports: [MongooseModule.forFeature([{ name: Restaurant.name, schema: RestaurantSchema }])],
   controllers: [RestaurantController, RestaurantDishController, PartnerDishController],
-  providers: [RestaurantsFacade, ListRestaurantsHandler],
+  providers: [RestaurantsFacade, GetRestaurantHandler, ListRestaurantsHandler],
   exports: [RestaurantsFacade],
 })
 class RestaurantsModule {}

--- a/packages/server/src/restaurants/api/RestaurantController.ts
+++ b/packages/server/src/restaurants/api/RestaurantController.ts
@@ -12,19 +12,22 @@ import {
   PaginationQuery,
   Url,
 } from '../../shared';
+import { GetRestaurantHandler } from '../domain/GetRestaurantHandler';
 import { ListRestaurantsHandler } from '../domain/ListRestaurantsHandler';
 import { RestaurantDto } from './RestaurantDto';
 import { RestaurantListDto } from './RestaurantListDto';
 
 @ApiController({ path: 'restaurants', name: 'Restaurants', description: 'Operations on restaurants' })
 class RestaurantController {
-  constructor(private readonly listRestaurantsHandler: ListRestaurantsHandler) {}
+  constructor(
+    private readonly getRestaurantHandler: GetRestaurantHandler,
+    private readonly listRestaurantsHandler: ListRestaurantsHandler,
+  ) {}
 
   @ApiObjectIdParam()
   @ApiGet({ name: 'restaurant', response: RestaurantDto })
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async findById(@Param('id') id: string) {
-    const restaurant = null; // TODO: Hook up GetRestaurantHandler, remove eslint-disable comment above
+    const restaurant = await this.getRestaurantHandler.exec({ id });
     if (!restaurant) return null;
     return plainToInstance(RestaurantDto, restaurant);
   }

--- a/packages/server/src/restaurants/api/RestaurantDto.ts
+++ b/packages/server/src/restaurants/api/RestaurantDto.ts
@@ -1,10 +1,9 @@
-import { ApiProperty, OmitType, PickType } from '@nestjs/swagger';
-import { Type } from 'class-transformer';
+import { ApiProperty, PickType } from '@nestjs/swagger';
 
 import { ApiObjectIdProperty } from '../../shared';
 import { CuisineTypes, RESTAURANT_CONSTANTS, RestaurantTags } from '../database';
-import { ShortenedDishDto } from '../dishes/api/DishDto';
 
+// TODO: Add logo
 class RestaurantDto {
   @ApiObjectIdProperty()
   readonly id: string;
@@ -27,14 +26,8 @@ class RestaurantDto {
 
   @ApiProperty({ enum: RestaurantTags, enumName: 'RestaurantTagEnum', isArray: true, example: ['pizza', 'zdrowa'] })
   readonly tags: RestaurantTags[];
-
-  @Type(() => ShortenedDishDto)
-  @ApiProperty({ type: [ShortenedDishDto] })
-  readonly dishes: ShortenedDishDto[];
 }
 
 class FavouriteRestaurantDto extends PickType(RestaurantDto, ['id', 'name'] as const) {}
 
-class RestaurantWithoutDishesDto extends OmitType(RestaurantDto, ['dishes'] as const) {}
-
-export { FavouriteRestaurantDto, RestaurantDto, RestaurantWithoutDishesDto };
+export { FavouriteRestaurantDto, RestaurantDto };

--- a/packages/server/src/restaurants/api/RestaurantListDto.ts
+++ b/packages/server/src/restaurants/api/RestaurantListDto.ts
@@ -1,12 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 
-import { RestaurantWithoutDishesDto } from './RestaurantDto';
+import { RestaurantDto } from './RestaurantDto';
 
 class RestaurantListDto {
-  @Type(() => RestaurantWithoutDishesDto)
-  @ApiProperty({ type: [RestaurantWithoutDishesDto] })
-  data: RestaurantWithoutDishesDto[];
+  @Type(() => RestaurantDto)
+  @ApiProperty({ type: [RestaurantDto] })
+  data: RestaurantDto[];
 
   @ApiProperty()
   pages: number;

--- a/packages/server/src/restaurants/dishes/api/DishDto.ts
+++ b/packages/server/src/restaurants/dishes/api/DishDto.ts
@@ -51,6 +51,4 @@ class UpdateDishDto extends CreateDishDto {}
 
 class FavouriteDishDto extends PickType(DishDto, ['id', 'name'] as const) {}
 
-class ShortenedDishDto extends OmitType(DishDto, ['allergens', 'nutritionalValue', 'ingredients'] as const) {}
-
-export { CreateDishDto, DishDto, FavouriteDishDto, ShortenedDishDto, UpdateDishDto };
+export { CreateDishDto, DishDto, FavouriteDishDto, UpdateDishDto };

--- a/packages/server/src/restaurants/domain/GetRestaurantHandler.ts
+++ b/packages/server/src/restaurants/domain/GetRestaurantHandler.ts
@@ -1,0 +1,22 @@
+import { InjectModel } from '@nestjs/mongoose';
+import { plainToInstance } from 'class-transformer';
+import { Model } from 'mongoose';
+
+import { Handler } from '../../shared';
+import { Restaurant, RestaurantDocument } from '../database';
+
+interface GetRestaurantRequest {
+  readonly id: string;
+}
+
+class GetRestaurantHandler implements Handler<GetRestaurantRequest, Restaurant | null> {
+  constructor(@InjectModel(Restaurant.name) private restaurantModel: Model<RestaurantDocument>) {}
+
+  async exec(req: GetRestaurantRequest): Promise<Restaurant | null> {
+    const restaurant = await this.restaurantModel.findById(req.id);
+    if (!restaurant || !restaurant?.profileCompleted) return null;
+    return plainToInstance(Restaurant, restaurant);
+  }
+}
+
+export { GetRestaurantHandler };

--- a/packages/server/test/Restaurants.test.ts
+++ b/packages/server/test/Restaurants.test.ts
@@ -45,7 +45,6 @@ describe(`${PATH}`, () => {
       description: 'Test!',
       cuisineType: ['włoska'],
       tags: ['pizza'],
-      dishes: [],
       profileCompleted: true,
     };
     const created = await fixture.db.restaurantModel.create(restaurant);

--- a/packages/server/test/Restaurants.test.ts
+++ b/packages/server/test/Restaurants.test.ts
@@ -37,4 +37,25 @@ describe(`${PATH}`, () => {
     expect(resp.status).toBe(HttpStatus.OK);
     expect(resp.body.data).toHaveLength(restaurants.filter((rest) => rest?.profileCompleted).length);
   });
+
+  it('GET /:id', async () => {
+    // Given
+    const restaurant = {
+      name: 'Restaurant',
+      description: 'Test!',
+      cuisineType: ['włoska'],
+      tags: ['pizza'],
+      dishes: [],
+      profileCompleted: true,
+    };
+    const created = await fixture.db.restaurantModel.create(restaurant);
+    const id = created._id?.toString();
+
+    // When
+    const resp = await fixture.req.get(`${PATH}/${id}`);
+
+    // Then
+    expect(resp.status).toBe(HttpStatus.OK);
+    expect(created).toEqual(expect.objectContaining(resp.body));
+  });
 });


### PR DESCRIPTION
Usunąłem `dishes` z `RestaurantDto`, czekam na wasze opinie na ten temat, moja argumentacja to:
1. Mamy już `/restaurant/{id}/dishes` które to wyświetla i byłoby bezsensowne jeśli te same informacje byłyby dostępne już tu.
2. Nie ma jak dobrze wesprzeć paginacji kiedy to jest pole obiektu zwracanego a nie osobny endpoint - jeśli restauracja ma 100 dań, to wyświetlamy je wszystkie (odpowiedź od serwera robi się ogromna), czy może tylko N pierwszych (skąd klient ma wiedzieć, że nie widzi wszystkiego?) - nie ma dobrego rozwiązania.
3. Pozwala to usunąć całkiem dwa rodzaje DTO (`ShortenedDish` i `RestaurantWithoutDishes`) - im mniej tym łatwiej się ogarnąć w kodzie i tym mniej rzeczy do maintainowania.

---

~~A tak trochę na marginesie, wydaje mi się, czy w bazie nie mamy żadnego powiązania `Restaurant <-> Dish`? Mając restaurację nie da się znaleźć jej dań, a mając danie nie da się znaleźć jego restauracji. To może spowodować trochę problemów przy handlerach partnera do zarządzania daniami.~~