### PR TITLE
Issue 201 connect shopping cart subpages

### DIFF
--- a/packages/client/src/components/CartSummary/CartSummary.tsx
+++ b/packages/client/src/components/CartSummary/CartSummary.tsx
@@ -29,7 +29,13 @@ const CartSummary = () => {
         </Typography>
       )}
       <Box textAlign='center'>
-        <Button href={routes.shoppingCart} color='secondary' variant='contained' size='large'>
+        <Button
+          href={cart.length !== 0 ? routes.shoppingCart : ''}
+          color='secondary'
+          variant='contained'
+          size='large'
+          disabled={cart.length === 0}
+        >
           Przejdź do zamówienia
         </Button>
       </Box>

--- a/packages/client/src/components/OrderStepper/OrderStepper.tsx
+++ b/packages/client/src/components/OrderStepper/OrderStepper.tsx
@@ -1,0 +1,27 @@
+import { Box, Step, StepButton, StepLabel, Stepper } from '@mui/material';
+
+import { routes } from '../../config';
+
+const STEPS = ['Podsumowanie', 'Uzupełnij dane', 'Zapłać i zamów'] as const;
+
+const OrderStepper = ({ activeStepIndex }: { activeStepIndex: number }) => {
+  const generateLabels = (label: string) => {
+    if (label === STEPS[0]) {
+      return <StepButton href={routes.shoppingCart}>{label}</StepButton>;
+    }
+    if (label === STEPS[1]) {
+      return <StepButton href={routes.shoppingCartData}>{label}</StepButton>;
+    }
+    return <StepLabel>{label}</StepLabel>;
+  };
+  return (
+    <Box minWidth='70vw' marginX='auto'>
+      <Stepper alternativeLabel activeStep={activeStepIndex}>
+        {STEPS.map((label) => {
+          return <Step key={label}>{generateLabels(label)}</Step>;
+        })}
+      </Stepper>
+    </Box>
+  );
+};
+export { OrderStepper };

--- a/packages/client/src/components/OrderStepper/OrderStepper.tsx
+++ b/packages/client/src/components/OrderStepper/OrderStepper.tsx
@@ -1,19 +1,32 @@
 import { Box, Step, StepButton, StepLabel, Stepper } from '@mui/material';
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 import { routes } from '../../config';
+import { useShoppingCart } from '../../contexts';
 
 const STEPS = ['Podsumowanie', 'Uzupełnij dane', 'Zapłać i zamów'] as const;
 
+const generateLabels = (label: string) => {
+  if (label === STEPS[0]) {
+    return <StepButton href={routes.shoppingCart}>{label}</StepButton>;
+  }
+  if (label === STEPS[1]) {
+    return <StepButton href={routes.shoppingCartData}>{label}</StepButton>;
+  }
+  return <StepLabel>{label}</StepLabel>;
+};
+
 const OrderStepper = ({ activeStepIndex }: { activeStepIndex: number }) => {
-  const generateLabels = (label: string) => {
-    if (label === STEPS[0]) {
-      return <StepButton href={routes.shoppingCart}>{label}</StepButton>;
+  const { cart } = useShoppingCart();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (cart.length === 0) {
+      navigate(routes.home, { replace: true });
     }
-    if (label === STEPS[1]) {
-      return <StepButton href={routes.shoppingCartData}>{label}</StepButton>;
-    }
-    return <StepLabel>{label}</StepLabel>;
-  };
+  }, [cart, navigate]);
+
   return (
     <Box minWidth='70vw' marginX='auto'>
       <Stepper alternativeLabel activeStep={activeStepIndex}>

--- a/packages/client/src/components/OrderStepper/index.tsx
+++ b/packages/client/src/components/OrderStepper/index.tsx
@@ -1,0 +1,1 @@
+export * from './OrderStepper'

--- a/packages/client/src/components/OrderStepper/index.tsx
+++ b/packages/client/src/components/OrderStepper/index.tsx
@@ -1,1 +1,1 @@
-export * from './OrderStepper'
+export * from './OrderStepper';

--- a/packages/client/src/components/OrderSummary/OrderDish.tsx
+++ b/packages/client/src/components/OrderSummary/OrderDish.tsx
@@ -25,7 +25,12 @@ const OrderDish = ({ orderDish }: OrderDishProps) => {
     <TableRow sx={{ height: '1px' }}>
       <TableCell sx={{ py: 5 }}>
         <Box sx={{ width: '11rem', height: '11rem', borderRadius: 4, overflow: 'hidden', mx: 'auto' }}>
-          <img alt={dish.name} src={dish.photo ? dish.photo : defaultPhoto} height='100%' />
+          <img
+            style={{ objectFit: 'cover', objectPosition: 'center', width: '100%' }}
+            alt={dish.name}
+            src={dish.photo ? dish.photo : defaultPhoto}
+            height='100%'
+          />
         </Box>
       </TableCell>
       <TableCell sx={{ height: '100%', py: 5 }}>

--- a/packages/client/src/components/index.ts
+++ b/packages/client/src/components/index.ts
@@ -6,6 +6,7 @@ export * from './Hero';
 export * from './HomeSteps';
 export * from './LoginForm';
 export * from './MediaCard';
+export * from './OrderStepper';
 export * from './OrderSummary';
 export * from './RegisterAndLoginQuestion';
 export * from './RegisterForm';

--- a/packages/client/src/pages/ShoppingCart/ShoppingCart.test.tsx
+++ b/packages/client/src/pages/ShoppingCart/ShoppingCart.test.tsx
@@ -1,11 +1,16 @@
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 
 import { ShoppingCart } from './ShoppingCart';
 
 describe('<ShoppingCart />', () => {
   it('should show price summary to user', async () => {
     // Given
-    render(<ShoppingCart />);
+    render(
+      <MemoryRouter>
+        <ShoppingCart />
+      </MemoryRouter>,
+    );
 
     // Then
     expect(await screen.findByText('Do zapłaty')).toBeInTheDocument();

--- a/packages/client/src/pages/ShoppingCart/ShoppingCart.tsx
+++ b/packages/client/src/pages/ShoppingCart/ShoppingCart.tsx
@@ -1,22 +1,12 @@
-import { Box, Stack, Step, StepLabel, Stepper } from '@mui/material';
+import { Box, Stack } from '@mui/material';
 
-import { OrderSummary } from '../../components';
-
-const STEPS = ['Podsumowanie', 'Uzupełnij dane', 'Zapłać i zamów'] as const;
+import { OrderStepper, OrderSummary } from '../../components';
 
 const ShoppingCart = () => {
   return (
     <Stack px={6} py={10} gap={10}>
       <Box minWidth='70vw' marginX='auto'>
-        <Stepper alternativeLabel activeStep={0}>
-          {STEPS.map((label) => {
-            return (
-              <Step key={label}>
-                <StepLabel>{label}</StepLabel>
-              </Step>
-            );
-          })}
-        </Stepper>
+        <OrderStepper activeStepIndex={0} />
       </Box>
       <OrderSummary />
     </Stack>

--- a/packages/client/src/pages/ShoppingCartData/ShoppingCart.test.tsx
+++ b/packages/client/src/pages/ShoppingCartData/ShoppingCart.test.tsx
@@ -1,11 +1,16 @@
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 
 import { ShoppingCartData } from './ShoppingCartData';
 
 describe('<ShoppingCart />', () => {
   it('should show address text', async () => {
     // Given
-    render(<ShoppingCartData />);
+    render(
+      <MemoryRouter>
+        <ShoppingCartData />
+      </MemoryRouter>,
+    );
 
     // Then
     expect(await screen.findByText('Adres dostawy')).toBeInTheDocument();

--- a/packages/client/src/pages/ShoppingCartData/ShoppingCartData.tsx
+++ b/packages/client/src/pages/ShoppingCartData/ShoppingCartData.tsx
@@ -1,13 +1,12 @@
-import { Box, Stack, Step, StepButton, StepLabel, Stepper } from '@mui/material';
+import { Stack } from '@mui/material';
 
-import { OrderDataCompletion } from '../../components/OrderDataCompletion';
-import { routes } from '../../config';
 import { OrderStepper } from '../../components';
+import { OrderDataCompletion } from '../../components/OrderDataCompletion';
 
 const ShoppingCartData = () => {
   return (
     <Stack px={6} py={10} gap={10}>
-    <OrderStepper activeStepIndex={1}/>
+      <OrderStepper activeStepIndex={1} />
       <OrderDataCompletion />
     </Stack>
   );

--- a/packages/client/src/pages/ShoppingCartData/ShoppingCartData.tsx
+++ b/packages/client/src/pages/ShoppingCartData/ShoppingCartData.tsx
@@ -2,27 +2,12 @@ import { Box, Stack, Step, StepButton, StepLabel, Stepper } from '@mui/material'
 
 import { OrderDataCompletion } from '../../components/OrderDataCompletion';
 import { routes } from '../../config';
-
-const STEPS = ['Podsumowanie', 'Uzupełnij dane', 'Zapłać i zamów'] as const;
+import { OrderStepper } from '../../components';
 
 const ShoppingCartData = () => {
   return (
     <Stack px={6} py={10} gap={10}>
-      <Box minWidth='70vw' marginX='auto'>
-        <Stepper alternativeLabel activeStep={1}>
-          {STEPS.map((label) => {
-            return (
-              <Step key={label}>
-                {label === 'Podsumowanie' ? (
-                  <StepButton href={routes.shoppingCart}>{label}</StepButton>
-                ) : (
-                  <StepLabel>{label}</StepLabel>
-                )}
-              </Step>
-            );
-          })}
-        </Stepper>
-      </Box>
+    <OrderStepper activeStepIndex={1}/>
       <OrderDataCompletion />
     </Stack>
   );

--- a/packages/client/src/pages/ShoppingCartPayment/ShoppingCartPayment.test.tsx
+++ b/packages/client/src/pages/ShoppingCartPayment/ShoppingCartPayment.test.tsx
@@ -1,11 +1,16 @@
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 
 import { ShoppingCartPayment } from './ShoppingCartPayment';
 
 describe('<ShoppingCart />', () => {
   it('should show address text', async () => {
     // Given
-    render(<ShoppingCartPayment />);
+    render(
+      <MemoryRouter>
+        <ShoppingCartPayment />
+      </MemoryRouter>,
+    );
 
     // Then
     expect(await screen.findByText('Uwagi do zamówienia')).toBeInTheDocument();

--- a/packages/client/src/pages/ShoppingCartPayment/ShoppingCartPayment.tsx
+++ b/packages/client/src/pages/ShoppingCartPayment/ShoppingCartPayment.tsx
@@ -1,13 +1,12 @@
-import { Stack} from '@mui/material';
+import { Stack } from '@mui/material';
 
+import { OrderStepper } from '../../components';
 import { OrderPayment } from '../../components/OrderPayment';
-import { routes } from '../../config';
-import { OrderStepper } from '../../components'
 
 const ShoppingCartPayment = () => {
   return (
     <Stack px={6} py={10} gap={10}>
-      <OrderStepper activeStepIndex={2}/>
+      <OrderStepper activeStepIndex={2} />
       <OrderPayment />
     </Stack>
   );

--- a/packages/client/src/pages/ShoppingCartPayment/ShoppingCartPayment.tsx
+++ b/packages/client/src/pages/ShoppingCartPayment/ShoppingCartPayment.tsx
@@ -1,29 +1,13 @@
-import { Box, Stack, Step, StepButton, StepLabel, Stepper } from '@mui/material';
+import { Stack} from '@mui/material';
 
 import { OrderPayment } from '../../components/OrderPayment';
 import { routes } from '../../config';
+import { OrderStepper } from '../../components'
 
-const STEPS = ['Podsumowanie', 'Uzupełnij dane', 'Zapłać i zamów'] as const;
-
-const generateLabels = (label: string) => {
-  if (label === STEPS[0]) {
-    return <StepButton href={routes.shoppingCart}>{label}</StepButton>;
-  }
-  if (label === STEPS[1]) {
-    return <StepButton href={routes.shoppingCartData}>{label}</StepButton>;
-  }
-  return <StepLabel>{label}</StepLabel>;
-};
 const ShoppingCartPayment = () => {
   return (
     <Stack px={6} py={10} gap={10}>
-      <Box minWidth='70vw' marginX='auto'>
-        <Stepper alternativeLabel activeStep={2}>
-          {STEPS.map((label) => {
-            return <Step key={label}>{generateLabels(label)}</Step>;
-          })}
-        </Stepper>
-      </Box>
+      <OrderStepper activeStepIndex={2}/>
       <OrderPayment />
     </Stack>
   );


### PR DESCRIPTION
- [x] przechodzenie między stronami i blokowanie następnych (to tak naprawdę zrobił już @KamilDudek )
- [x] wyodrębnienie Steppera w komponencie
- [x] poprawka zdjęć w zamówieniu (przy okazji)
- [x] dodanie sprawdzenia czy mamy coś wybranego przy przechodzenia z main dalej
- [x] przekierowanie do strony głównej jeśli nie ma nic w koszyku (w każdym kroku) - nie jest to super rozwiązanie, bo może lepiej byłoby do strony koszyka z informacją, że koszyk jest pusty, ale przekierowanie do str. głównej było szybsze :D

Jeżeli chodzi o sprawdzenie czy uzupełniliśmy dane (np. krok 2) to wydaje mi się, że będzie załatwione przy walidacji @mmejer w #210. Jeśli nie będzie przeładowania formularza, no to wszystkie stany uzupełnionych pól powinny być zachowane i wtedy będzie można do tych podstron wrócić z wypełnionymi danymi.